### PR TITLE
Update README.md: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Your goal in this question is to estimate homographies between two images using 
     | Normal Image | Perspective Image |
     | ----------- | ----------- |
     |  <img src="figures/desk-normal.png" height="150">  | <img src="figures/desk-perspective.png" height="150">  |
- 2. Run your code on the pair of images provided in the `data/q3` folder as well as `1` additional pair of images that you captured. We have provided annotation of the four corner points in `desk-perspective.png` (in anti-clockwise order) in `annotation/q3_annotation.npy`. The format is same as `annotation/q1_annotation.npy`. 
+ 2. Run your code on the pair of images provided in the `data/q3` folder as well as `1` additional pair of images that you captured. We have provided annotation of the four corner points in `desk-perspective.png` (in **clockwise** order) in `annotation/q3_annotation.npy`. The format is same as `annotation/q1_annotation.npy`. 
 
 **Submission**
 1. Input Images


### PR DESCRIPTION
<img width="406" height="116" alt="Screenshot 2025-10-01 at 11 27 20 AM" src="https://github.com/user-attachments/assets/cc70ca1c-3962-4a21-a333-1003a62cdf62" />

The coordinates, assuming opencv (u,v) coordinates with the origin in the top left corner, are actually clockwise, not counter clockwise.
